### PR TITLE
Install ca certificates to prevent problems with https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM debian:jessie
 
 MAINTAINER Or Elimelech <0r3limelech@gmail.com>
 
+RUN apt-get update && apt-get install -y \
+	ca-certificates
+
 ADD https://github.com/bitly/google_auth_proxy/releases/download/v1.0/google_auth_proxy-1.0.linux-amd64.go1.3.tar.gz /tmp/google_auth_proxy.tgz
 
 WORKDIR /tmp


### PR DESCRIPTION
I got ```x509: failed to load system roots and no roots provided ``` error and noticed the image does not have CA certificates installed, hence this PR.
